### PR TITLE
Support IdP token header placeholder

### DIFF
--- a/api/server/services/Endpoints/custom/initialize.js
+++ b/api/server/services/Endpoints/custom/initialize.js
@@ -28,7 +28,7 @@ const initializeClient = async ({ req, res, endpointOption, optionsOnly, overrid
   const CUSTOM_API_KEY = extractEnvVariable(endpointConfig.apiKey);
   const CUSTOM_BASE_URL = extractEnvVariable(endpointConfig.baseURL);
 
-  let resolvedHeaders = resolveHeaders(endpointConfig.headers, req.user);
+  let resolvedHeaders = resolveHeaders(endpointConfig.headers, req.user, undefined, req.idpToken);
 
   if (CUSTOM_API_KEY.match(envVarRegex)) {
     throw new Error(`Missing API Key for ${endpoint}.`);

--- a/api/server/services/Endpoints/custom/initialize.spec.js
+++ b/api/server/services/Endpoints/custom/initialize.spec.js
@@ -56,6 +56,7 @@ describe('custom/initializeClient', () => {
   const mockRequest = {
     body: { endpoint: 'test-endpoint' },
     user: { id: 'user-123', email: 'test@example.com' },
+    idpToken: 'idp-123',
     app: { locals: {} },
   };
   const mockResponse = {};
@@ -70,6 +71,8 @@ describe('custom/initializeClient', () => {
     expect(resolveHeaders).toHaveBeenCalledWith(
       { 'x-user': '{{LIBRECHAT_USER_ID}}', 'x-email': '{{LIBRECHAT_USER_EMAIL}}' },
       { id: 'user-123', email: 'test@example.com' },
+      undefined,
+      'idp-123',
     );
   });
 

--- a/api/server/services/Endpoints/openAI/initialize.js
+++ b/api/server/services/Endpoints/openAI/initialize.js
@@ -83,6 +83,8 @@ const initializeClient = async ({
     clientOptions.headers = resolveHeaders(
       { ...headers, ...(clientOptions.headers ?? {}) },
       req.user,
+      undefined,
+      req.idpToken,
     );
 
     clientOptions.titleConvo = azureConfig.titleConvo;

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -180,6 +180,7 @@ async function createMCPTool({ req, res, toolKey, provider: _provider }) {
           signal: derivedSignal,
         },
         user: config?.configurable?.user,
+        idpToken: req.idpToken,
         customUserVars,
         flowManager,
         tokenMethods: {

--- a/packages/api/src/endpoints/openai/initialize.ts
+++ b/packages/api/src/endpoints/openai/initialize.ts
@@ -90,6 +90,8 @@ export const initializeOpenAI = async ({
     clientOptions.headers = resolveHeaders(
       { ...headers, ...(clientOptions.headers ?? {}) },
       req.user,
+      undefined,
+      req.idpToken,
     );
 
     const groupName = modelGroupMap[modelName || '']?.group;

--- a/packages/api/src/mcp/manager.ts
+++ b/packages/api/src/mcp/manager.ts
@@ -376,6 +376,7 @@ export class MCPManager {
     serverName,
     flowManager,
     customUserVars,
+    idpToken,
     tokenMethods,
     oauthStart,
     oauthEnd,
@@ -385,6 +386,7 @@ export class MCPManager {
     serverName: string;
     flowManager: FlowStateManager<MCPOAuthTokens | null>;
     customUserVars?: Record<string, string>;
+    idpToken?: string;
     tokenMethods?: TokenMethods;
     oauthStart?: (authURL: string) => Promise<void>;
     oauthEnd?: () => Promise<void>;
@@ -438,7 +440,7 @@ export class MCPManager {
       );
     }
 
-    config = { ...(processMCPEnv(config, user, customUserVars) ?? {}) };
+    config = { ...(processMCPEnv(config, user, customUserVars, idpToken) ?? {}) };
     /** If no in-memory tokens, tokens from persistent storage */
     let tokens: MCPOAuthTokens | null = null;
     if (tokenMethods?.findToken) {
@@ -823,6 +825,7 @@ export class MCPManager {
     flowManager,
     oauthStart,
     oauthEnd,
+    idpToken,
     customUserVars,
   }: {
     user?: TUser;
@@ -836,6 +839,7 @@ export class MCPManager {
     flowManager: FlowStateManager<MCPOAuthTokens | null>;
     oauthStart?: (authURL: string) => Promise<void>;
     oauthEnd?: () => Promise<void>;
+    idpToken?: string;
   }): Promise<t.FormattedToolResponse> {
     /** User-specific connection */
     let connection: MCPConnection | undefined;
@@ -854,6 +858,7 @@ export class MCPManager {
           oauthStart,
           oauthEnd,
           signal: options?.signal,
+          idpToken,
           customUserVars,
         });
       } else {

--- a/packages/api/src/types/openai.ts
+++ b/packages/api/src/types/openai.ts
@@ -52,6 +52,7 @@ export interface RequestData {
   user: {
     id: string;
   };
+  idpToken?: string;
   body: {
     model?: string;
     endpoint?: string;

--- a/packages/api/src/utils/env.spec.ts
+++ b/packages/api/src/utils/env.spec.ts
@@ -201,6 +201,31 @@ describe('resolveHeaders', () => {
     });
   });
 
+  it('should replace IdP token placeholder when token provided', () => {
+    const headers = {
+      Authorization: 'Bearer {{LIBRECHAT_IDP_TOKEN}}',
+    };
+    const result = resolveHeaders(headers, undefined, undefined, 'token-abc');
+    expect(result).toEqual({ Authorization: 'Bearer token-abc' });
+  });
+
+  it('should leave IdP token placeholder unchanged when token missing', () => {
+    const headers = {
+      Authorization: 'Bearer {{LIBRECHAT_IDP_TOKEN}}',
+    };
+    const result = resolveHeaders(headers);
+    expect(result).toEqual({ Authorization: 'Bearer {{LIBRECHAT_IDP_TOKEN}}' });
+  });
+
+  it('should prioritize custom vars over IdP token', () => {
+    const headers = {
+      Authorization: 'Bearer {{LIBRECHAT_IDP_TOKEN}}',
+    };
+    const customVars = { LIBRECHAT_IDP_TOKEN: 'custom-token' };
+    const result = resolveHeaders(headers, undefined, customVars, 'real-token');
+    expect(result).toEqual({ Authorization: 'Bearer custom-token' });
+  });
+
   it('should handle boolean user fields', () => {
     const user = createTestUser({
       id: 'user-123',


### PR DESCRIPTION
## Summary
- add optional `idpToken` support to `resolveHeaders` and `processMCPEnv`
- replace `{{LIBRECHAT_IDP_TOKEN}}` with provided token
- pass token through OpenAI and custom endpoint initializers
- update related types and tests

## Testing
- `npm run test:api` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687126f66a9c832cb4bf643de071a795